### PR TITLE
Fix: Secure API key management and unify UserProfile.fullName storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# MaaKosh specific API Keys file
+MaaKosh/Core/APIKeys.swift

--- a/MaaKosh/Core/APIKeys.swift.example
+++ b/MaaKosh/Core/APIKeys.swift.example
@@ -1,0 +1,27 @@
+// MaaKosh/Core/APIKeys.swift.example
+
+/*
+IMPORTANT:
+1. RENAME THIS FILE to `APIKeys.swift` (remove .example).
+2. ENSURE `APIKeys.swift` is listed in your `.gitignore` file to prevent committing your actual keys.
+3. REPLACE the placeholder values below with your actual API keys and channel ID.
+
+This file provides a centralized place to store your API keys.
+The actual `APIKeys.swift` file (once you rename this one and add your keys) should NOT be committed to version control.
+*/
+
+struct APIKeys {
+    // Google Generative AI (Gemini) API Key
+    // Obtain from: https://aistudio.google.com/app/apikey
+    static let geminiAPIKey = "PASTE_YOUR_GOOGLE_GEMINI_API_KEY_HERE"
+
+    // ThingSpeak API Key and Channel ID (for Neonatal Patch Vitals)
+    // Obtain from your ThingSpeak channel settings
+    static let thingspeakAPIKey = "PASTE_YOUR_THINGSPEAK_API_KEY_HERE"
+    static let thingspeakChannelID = "PASTE_YOUR_THINGSPEAK_CHANNEL_ID_HERE"
+}
+
+// Note: After creating APIKeys.swift and adding your keys,
+// the application will use these values.
+// Make sure the project compiles and accesses these keys correctly.
+// Example usage in a file: private let apiKey = APIKeys.geminiAPIKey

--- a/MaaKosh/Features/Maatri/MaatriView.swift
+++ b/MaaKosh/Features/Maatri/MaatriView.swift
@@ -88,7 +88,7 @@ struct MaatriView: View {
     @State private var conversationSummary: String = ""
     
     // Initialize Gemini model with API key
-    private let apiKey = "AIzaSyCueBkZoml0YMVXHxtMZeE7Xn-0iqDRpGU"
+    private let apiKey = APIKeys.geminiAPIKey
     private var model: GenerativeModel {
         let config = GenerationConfig(maxOutputTokens: 800)
         return GenerativeModel(name: "gemini-1.5-pro", apiKey: apiKey, generationConfig: config)

--- a/MaaKosh/Features/NewbornCare/NewbornCareView.swift
+++ b/MaaKosh/Features/NewbornCare/NewbornCareView.swift
@@ -1859,7 +1859,7 @@ struct GeminiAICareView: View {
     let feedingRecords: [FeedingRecord]
     let vaccinationRecords: [VaccinationRecord]
     
-    private let geminiAPIKey = "AIzaSyCueBkZoml0YMVXHxtMZeE7Xn-0iqDRpGU"
+    private let geminiAPIKey = APIKeys.geminiAPIKey
     
     @State private var messages: [ChatMessage] = []
     @State private var userInput: String = ""
@@ -2367,8 +2367,8 @@ struct VitalMonitoringView: View {
     
     let babyName: String
     
-    private let thingspeakChannel = "2916872"
-    private let thingspeakAPIKey = "BQFLBK7JHE2VHZH4"
+    private let thingspeakChannel = APIKeys.thingspeakChannelID
+    private let thingspeakAPIKey = APIKeys.thingspeakAPIKey
     
     @State private var bilirubinData: [VitalDataPoint] = []
     @State private var temperatureData: [VitalDataPoint] = []

--- a/MaaKosh/Features/Onboarding/OnboardingData.swift
+++ b/MaaKosh/Features/Onboarding/OnboardingData.swift
@@ -10,6 +10,7 @@ import FirebaseFirestore
 
 // User profile model to store information after signup
 struct UserProfile: Codable {
+    var fullName: String = "" // Added
     var age: Int = 0
     var phoneNumber: String = ""
     var partnerName: String = ""
@@ -33,6 +34,7 @@ struct UserProfile: Codable {
         let db = Firestore.firestore()
         
         let userData: [String: Any] = [
+            "fullName": fullName, // Added
             "age": age,
             "phoneNumber": phoneNumber,
             "partnerName": partnerName,

--- a/MaaKosh/Features/PrePregnancy/PrePregnancyView.swift
+++ b/MaaKosh/Features/PrePregnancy/PrePregnancyView.swift
@@ -39,7 +39,7 @@ struct PrePregnancyView: View {
     private let monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
     
     // AI model for generating recommendations
-    private let apiKey = "AIzaSyCueBkZoml0YMVXHxtMZeE7Xn-0iqDRpGU"
+    private let apiKey = APIKeys.geminiAPIKey
     private var model: GenerativeModel {
         let config = GenerationConfig(maxOutputTokens: 500)
         return GenerativeModel(name: "gemini-1.5-pro", apiKey: apiKey, generationConfig: config)
@@ -2415,7 +2415,7 @@ struct GeminiAIFertilityGuideView: View {
     let periodLength: Int
     let cycleEvents: [CycleEvent]
     
-    private let geminiAPIKey = "AIzaSyCueBkZoml0YMVXHxtMZeE7Xn-0iqDRpGU"
+    private let geminiAPIKey = APIKeys.geminiAPIKey
     
     @State private var messages: [ChatMessage] = []
     @State private var userInput: String = ""

--- a/MaaKosh/Features/Profile/ProfileView.swift
+++ b/MaaKosh/Features/Profile/ProfileView.swift
@@ -768,7 +768,6 @@ struct ProfileView: View {
             }
             
             // Clear local data
-            UserDefaults.standard.removeObject(forKey: "userFullName")
             UserDefaults.standard.removeObject(forKey: "userProfileImage")
             
             // Return to auth screen
@@ -1481,18 +1480,6 @@ struct EditTextField: View {
             .padding()
             .background(Color.maakoshLightPink.opacity(0.1))
             .cornerRadius(10)
-        }
-    }
-}
-
-// Extension to add fullName property to UserProfile
-extension UserProfile {
-    var fullName: String {
-        get {
-            UserDefaults.standard.string(forKey: "userFullName") ?? ""
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: "userFullName")
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Follow these instructions to get a copy of the project up and running on your lo
 *   **Xcode:** Download the latest version from the Mac App Store.
 *   **Apple Developer Account:** Required to install the app on a physical device.
 *   **Firebase Account:** To enable Firebase-dependent features (Authentication, Firestore), you'll need to set up your own Firebase project and add your `GoogleService-Info.plist` file.
+*   **API Keys for AI and Vitals Monitoring:**
+    *   The app uses Google Generative AI (Gemini) for its AI features and ThingSpeak for neonatal patch vitals. You will need to obtain API keys for these services.
+    1.  Navigate to the `MaaKosh/Core/` directory.
+    2.  You'll find a file named `APIKeys.swift.example`.
+    3.  **Duplicate this file and rename the copy to `APIKeys.swift`**.
+    4.  Open `APIKeys.swift` and replace the placeholder strings with your actual API keys:
+        *   `geminiAPIKey`: Your Google AI Studio API key.
+        *   `thingspeakAPIKey`: Your ThingSpeak Channel API Read Key.
+        *   `thingspeakChannelID`: Your ThingSpeak Channel ID.
+    5.  **Important:** The `APIKeys.swift` file is already listed in `.gitignore` to ensure your private keys are not committed to version control. Do not remove it from `.gitignore`.
 
 ### Building the Project
 
@@ -134,7 +144,7 @@ Follow these instructions to get a copy of the project up and running on your lo
 ### Important Notes
 
 *   **Functionality without Firebase:** Some features, particularly those related to AI and data persistence (like cycle tracking history, user profiles), will require a working Firebase setup. The app might run without it, but these features will likely be disabled or non-functional.
-*   **API Keys:** The app uses Google Generative AI and ThingSpeak. You might need to configure API keys for these services for full feature access. The current `PrePregnancyView.swift` and `NewbornCareView.swift` files seem to have API keys hardcoded. For a real-world scenario, these should be managed securely (e.g., via Xcode configurations or a `.xcconfig` file not committed to the repo).
+*   **API Keys Configuration:** Ensure you have configured your API keys in `MaaKosh/Core/APIKeys.swift` as described in the Prerequisites section for AI features and neonatal vitals monitoring to function correctly.
 
 ---
 


### PR DESCRIPTION
This commit addresses two critical issues:

1.  **Hardcoded API Keys:**
    *   I removed hardcoded Google Gemini and ThingSpeak API keys from source files.
    *   I introduced an `APIKeys.swift.example` file in `MaaKosh/Core/` for you to copy to `APIKeys.swift` and populate with your actual keys.
    *   I added `MaaKosh/Core/APIKeys.swift` to `.gitignore`.
    *   I updated relevant views (`MaatriView`, `PrePregnancyView`, `GeminiAIFertilityGuideView`, `GeminiAICareView`, `VitalMonitoringView`) to reference keys from the `APIKeys` struct.
    *   I updated `README.md` with instructions for API key setup.
    *   This significantly improves security by preventing API keys from being committed to version control.

2.  **Inconsistent UserProfile.fullName Storage:**
    *   I removed the `UserProfile` extension that managed `fullName` via `UserDefaults`.
    *   I added `fullName` as a direct property to the `UserProfile` struct in `OnboardingData.swift`.
    *   I updated `UserProfile.saveToFirestore()` to include `fullName`.
    *   I ensured `ProfileView.loadUserProfile()` loads `fullName` from Firestore.
    *   I removed `UserDefaults` manipulation for `fullName` in `ProfileView.deleteUserData()`.
    *   This change ensures `fullName` is consistently managed in Firestore, improving data integrity.